### PR TITLE
Typo: Fixed variable spelling of keyboard

### DIFF
--- a/Typist/ViewController.swift
+++ b/Typist/ViewController.swift
@@ -13,12 +13,12 @@ class ViewController: UIViewController {
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var textLabel: UILabel!
     
-    let keybaord = Typist.shared
+    let keyboard = Typist.shared
     
     override func viewDidLoad() {
         super.viewDidLoad()
     
-        keybaord
+        keyboard
             .on(event: .didShow) { [unowned self] (options) in
                 self.textLabel.text = "New Keyboard Frame is \(options.endFrame)."
             }


### PR DESCRIPTION
Corrected small typo in the spelling of the variable named "keyboard"
