### PR TITLE
Silencing the warning

### DIFF
--- a/Typist.swift
+++ b/Typist.swift
@@ -87,6 +87,7 @@ public class Typist: NSObject {
     /// - parameter event: Event on which callback should be executed.
     /// - parameter do: Closure of code which will be executed on keyboard `event`.
     /// - returns: `Self` for convenience so many `on` functions can be chained.
+    @discardableResult
     public func on(event: KeyboardEvent, do callback: TypistCallback?) -> Self {
         callbacks[event] = callback
         return self


### PR DESCRIPTION
When there's no need to store the result of the last `.on(:_,:_)` function call, the warning is raised. Fixed that. Looks like in most cases this behaviour is more practical.