### PR TITLE
Add UIView.AnimationOptions variable to KeyboardOptions struct

### DIFF
--- a/Typist.swift
+++ b/Typist.swift
@@ -55,6 +55,20 @@ public class Typist: NSObject {
         
         /// Identifies the duration of the animation in seconds.
         public let animationDuration: Double
+     
+        /// Maps the animationCurve to it's respective `UIView.AnimationOptions` value.
+        public var animationOptions: UIView.AnimationOptions {
+            switch self.animationCurve {
+                case UIView.AnimationCurve.easeIn:
+                    return UIView.AnimationOptions.curveEaseIn
+                case UIView.AnimationCurve.easeInOut:
+                    return UIView.AnimationOptions.curveEaseInOut
+                case UIView.AnimationCurve.easeOut:
+                    return UIView.AnimationOptions.curveEaseOut
+                case UIView.AnimationCurve.linear:
+                    return UIView.AnimationOptions.curveLinear
+            }
+        }
     }
     
     /// TypistCallback


### PR DESCRIPTION
In order to smoothly animate our views at par with iOS keyboard, we must use`UIView.animate(withDuration:delay:options:animations:completion:)` method which takes `UIViewAnimationOptions` as it's options argument value.

Right now we must convert `KeyboardOptions.animationCurve` from `UIView.AnimationCurve` to `UIView.AnimationOptions` in order to call our `animate` function.

To make our lives easier and our code cleaner, I've implemented a helper variable called `animationOptions` in `Typist.KeyboardOptions` struct, which transforms a given `UIView.AnimationCurve` to its respective `UIView.AnimationOptions` value.