### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,9 @@ let package = Package(
     targets: [
         .target(
             name: "Typist",
-            path: "Typist.swift"
+            path: ".",
+            exclude: ["Typist"],
+            sources: "Typist.swift"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             name: "Typist",
             path: ".",
             exclude: ["Typist"],
-            sources: "Typist.swift"
+            sources: ["Typist.swift"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Typist",
+    // platforms: [.iOS("8.0")],
+    products: [
+        .library(name: "Typist", targets: ["Typist"])
+    ],
+    targets: [
+        .target(
+            name: "Typist",
+            path: "Typist.swift"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Platform](https://img.shields.io/cocoapods/p/Typist.svg?style=flat)](http://cocoapods.org/pods/Typist)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Typist.svg)](https://img.shields.io/cocoapods/v/Typist.svg)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/totocaster/Typist)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![Twitter](https://img.shields.io/badge/twitter-@totocaster-blue.svg)](http://twitter.com/totocaster)
 
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Create a `Cartfile` that lists the framework and run `carthage update`. Follow t
 github "totocaster/Typist"
 ```
 
-### Accio
+#### Accio
 
 Initialize your project with [Accio](https://github.com/JamitLabs/Accio) using the `init` command.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ Create a `Cartfile` that lists the framework and run `carthage update`. Follow t
 github "totocaster/Typist"
 ```
 
+### Accio
+
+Initialize your project with [Accio](https://github.com/JamitLabs/Accio) using the `init` command.
+
+Add the following to your Package.swift:
+
+```swift
+.package(url: "https://github.com/totocaster/Typist.git", .upToNextMajor(from: "1.3.2")),
+```
+
+Next, add `Typist` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "Typist",
+    ]
+),
+```
+
+Then run `accio update`.
+
 #### Manually
 Download and drop ```Typist.swift``` in your project.
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.